### PR TITLE
tweak spotless config to prevent reformatting of pom.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =====
 
 - Strings in the following fields are escaped using HTML entities: title, filename, file description, file format, variable name, variable description. See https://github.com/gdcc/exporter-croissant/pull/8
+- Tweaked spotless (code formatting) config. See https://github.com/gdcc/exporter-croissant/pull/12
 
 0.1.2
 =====

--- a/pom.xml
+++ b/pom.xml
@@ -125,13 +125,17 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.36.0</version>
+        <version>2.43.0</version>
         <configuration>
           <java>
-            <importOrder />
-            <removeUnusedImports />
+            <importOrder>
+              <wildcardsLast>false</wildcardsLast>
+            </importOrder>
+            <removeUnusedImports>
+              <engine>google-java-format</engine>
+            </removeUnusedImports>
             <googleJavaFormat>
-              <version>1.15.0</version>
+              <version>1.17.0</version>
               <style>AOSP</style>
               <reflowLongStrings>true</reflowLongStrings>
             </googleJavaFormat>
@@ -140,7 +144,9 @@
             <includes>
               <include>pom.xml</include>
             </includes>
-            <sortPom />
+            <sortPom>
+              <encoding>UTF-8</encoding>
+            </sortPom>
           </pom>
         </configuration>
       </plugin>

--- a/src/main/java/io/gdcc/spi/export/croissant/CroissantExporter.java
+++ b/src/main/java/io/gdcc/spi/export/croissant/CroissantExporter.java
@@ -1,11 +1,9 @@
 package io.gdcc.spi.export.croissant;
 
 import com.google.auto.service.AutoService;
-
 import io.gdcc.spi.export.ExportDataProvider;
 import io.gdcc.spi.export.ExportException;
 import io.gdcc.spi.export.Exporter;
-
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
@@ -15,14 +13,12 @@ import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
 import jakarta.ws.rs.core.MediaType;
-
-import org.apache.commons.text.StringEscapeUtils;
-
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import org.apache.commons.text.StringEscapeUtils;
 
 /** https://github.com/mlcommons/croissant */
 @AutoService(Exporter.class)

--- a/src/test/java/io/gdcc/spi/export/croissant/CroissantExporterTest.java
+++ b/src/test/java/io/gdcc/spi/export/croissant/CroissantExporterTest.java
@@ -3,7 +3,6 @@ package io.gdcc.spi.export.croissant;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.gdcc.spi.export.ExportDataProvider;
-
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -11,11 +10,6 @@ import jakarta.json.JsonReader;
 import jakarta.json.JsonWriter;
 import jakarta.json.JsonWriterFactory;
 import jakarta.json.stream.JsonGenerator;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -29,6 +23,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class CroissantExporterTest {
 


### PR DESCRIPTION
- Closes #11 

`<sortPom />` for example was being reformatted to
`<sortPom></sortPom>` every time we run `mvn spotless::apply`.

So, we insert some no-op [config](https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md) to this and the other two elements that were being similarly expanded.

Hopefully, the next time we use the maven release plugin, it will leave these elements alone.

This is just a workaround, of course. As discussed [in Zulip](https://dataverse.zulipchat.com/#narrow/channel/379673-dev/topic/code.20formatting.20.28Spotless.2C.20Checkstyle.2C.20etc.2E.29/near/508309571) we could also switch from spotless to something else. 🤷 